### PR TITLE
Add css config:

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,7 @@
+p { text-align: justify;}
+
+img[src*='#center'] {
+    display: block;
+    margin: auto;
+    max-height: 450px;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,12 +11,13 @@ nav:
       - apps:
           - ground-truth: reference/apps/ground-truth.md
           - train-config:
-            - evaluation: reference/apps/train-config-evaluation.md
-            - generation: reference/apps/train-config-generation.md
+              - evaluation: reference/apps/train-config-evaluation.md
+              - generation: reference/apps/train-config-generation.md
       - plots:
           - images: reference/plots/images.md
           - boxes: reference/plots/boxes.md
-
+extra_css:
+  - css/extra.css
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
- Center and max height for images
- Add #center tag for images

In case you want to center an image in the docs you need to add url hash #center to the path:
`![alt image][/images/example.png#center]`