### PR TITLE
Ignore E203 error in flake8 conflicting with black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,5 +6,5 @@
         # Exclude some missing docstrings errors
         D100, D101, D104, D105, D106, D107
         # Exclude errors conflicting with black
-        W503, E501
+        W503, E501, E203
     per-file-ignores = tests/*: D1


### PR DESCRIPTION
These type of conflicting errors should be always ignored. 
https://github.com/psf/black/issues/315