### PR TITLE
add windows support by updating dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
   pandas==1.2.1
   pillow==8.1.0
   plotly==4.14.3
-  pycocotools-fix==2.0.0.9
+  pycocotools==2.0.2
   kaleido==v0.1.0
   scikit-learn==0.24.1
   fire==0.4.0


### PR DESCRIPTION
@mmeendez8 @igonro @cgiraldo thanks a lot for this awesome package!

pycocotools-fix package currently doesnt work on windows: https://github.com/junjuew/cocoapi/pull/4

official pycocotools package is constantly updated by the facebook research team: https://pypi.org/project/pycocotools/

by accepting this pr, pyodi package will be supported on windows.