### PR TITLE
Fix macOS install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ install_requires =
   numpy==1.20.1
   loguru==0.5.3
   matplotlib==3.3.4
-  numba==0.52.0
+  numba>=0.52.0
   pandas==1.2.1
   pillow==8.1.0
   plotly==5.2.2


### PR DESCRIPTION
For some reason, there is no `numba==0.52.0` on macOS.

Might be worth adding macOS to C.I. workflow.