### PR TITLE
Feature: make JSON indentation configurable when merging COCO files

### DIFF
--- a/pyodi/apps/coco/coco_merge.py
+++ b/pyodi/apps/coco/coco_merge.py
@@ -16,7 +16,7 @@ and adding all existent categories.
 # API REFERENCE
 """  # noqa: E501
 import json
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional
 
 from loguru import logger
 
@@ -94,6 +94,6 @@ def coco_merge(
     )
 
     with open(output_file, "w") as f:
-        json.dump(output, f, indent=json_indentation)
+        json.dump(output, f, indent=indent)
 
     return output_file

--- a/pyodi/apps/coco/coco_merge.py
+++ b/pyodi/apps/coco/coco_merge.py
@@ -26,7 +26,7 @@ def coco_merge(
     input_extend: str,
     input_add: str,
     output_file: str,
-    json_indentation: Union[int, None] = 2,
+    indent: Optional[int] = None,
 ) -> str:
     """Merge COCO annotation files.
 
@@ -34,7 +34,7 @@ def coco_merge(
         input_extend: Path to input file to be extended.
         input_add: Path to input file to be added.
         output_file : Path to output file with merged annotations.
-        json_indentation: If set to a non-negative integer, then JSON array elements and object members will be pretty-printed with that indent level. An indent level of `0` will only insert newlines. `None` is the most compact representation (no indentation).
+        indent: Argument passed to `json.dump`. See https://docs.python.org/3/library/json.html#json.dump.
     """
     with open(input_extend, "r") as f:
         data_extend = json.load(f)

--- a/pyodi/apps/coco/coco_merge.py
+++ b/pyodi/apps/coco/coco_merge.py
@@ -23,10 +23,7 @@ from loguru import logger
 
 @logger.catch(reraise=True)
 def coco_merge(
-    input_extend: str,
-    input_add: str,
-    output_file: str,
-    indent: Optional[int] = None,
+    input_extend: str, input_add: str, output_file: str, indent: Optional[int] = None,
 ) -> str:
     """Merge COCO annotation files.
 

--- a/pyodi/apps/coco/coco_merge.py
+++ b/pyodi/apps/coco/coco_merge.py
@@ -16,19 +16,25 @@ and adding all existent categories.
 # API REFERENCE
 """  # noqa: E501
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from loguru import logger
 
 
 @logger.catch(reraise=True)
-def coco_merge(input_extend: str, input_add: str, output_file: str,) -> str:
+def coco_merge(
+    input_extend: str,
+    input_add: str,
+    output_file: str,
+    json_indentation: Union[int, None] = 2,
+) -> str:
     """Merge COCO annotation files.
 
     Args:
         input_extend: Path to input file to be extended.
         input_add: Path to input file to be added.
         output_file : Path to output file with merged annotations.
+        json_indentation: If set to a non-negative integer, then JSON array elements and object members will be pretty-printed with that indent level. An indent level of `0` will only insert newlines. `None` is the most compact representation (no indentation).
     """
     with open(input_extend, "r") as f:
         data_extend = json.load(f)
@@ -88,6 +94,6 @@ def coco_merge(input_extend: str, input_add: str, output_file: str,) -> str:
     )
 
     with open(output_file, "w") as f:
-        json.dump(output, f, indent=2)
+        json.dump(output, f, indent=json_indentation)
 
     return output_file

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ dev =
   mkdocs==1.1.2
   mkdocstrings==0.14.0
   mkdocs-material==6.2.8
+  mock==4.0.3
   mypy==0.800
   pre-commit==2.10.1
   pydocstyle==5.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyodi
-version = 0.0.6
+version = 0.0.7
 author = Pyodi
 description = Object Detection Insights
 long_description = file: README.md

--- a/tests/apps/test_coco_merge.py
+++ b/tests/apps/test_coco_merge.py
@@ -1,6 +1,8 @@
 import json
 
-from mock import patch, ANY
+import pytest
+from mock import ANY, patch
+
 from pyodi.apps.coco.coco_merge import coco_merge
 
 
@@ -59,7 +61,8 @@ def test_coco_merge(tmp_path):
     assert [i["category_id"] for i in data["annotations"]] == [1, 2, 1, 3, 3, 1]
 
 
-def test_coco_merge_with_json_indent(tmp_path):
+@pytest.mark.parametrize("indent", [None, 2])
+def test_coco_merge_with_json_indent(tmp_path, indent):
     images = [{"id": 0, "file_name": "0.jpg"}]
     anns1 = [{"image_id": 0, "category_id": 0, "id": 0}]
     anns2 = [{"image_id": 0, "category_id": 1, "id": 0}]
@@ -79,15 +82,6 @@ def test_coco_merge_with_json_indent(tmp_path):
             input_extend=tmp_path / "0.json",
             input_add=tmp_path / "1.json",
             output_file=tmp_path / "result.json",
-            indent=None,
+            indent=indent,
         )
-        mock.assert_called_once_with(ANY, ANY, indent=None)
-
-    with patch("json.dump") as mock:
-        coco_merge(
-            input_extend=tmp_path / "0.json",
-            input_add=tmp_path / "1.json",
-            output_file=tmp_path / "result.json",
-            indent=2,
-        )
-        mock.assert_called_once_with(ANY, ANY, indent=2)
+        mock.assert_called_once_with(ANY, ANY, indent=indent)

--- a/tests/apps/test_coco_merge.py
+++ b/tests/apps/test_coco_merge.py
@@ -1,5 +1,6 @@
 import json
 
+from mock import patch, ANY
 from pyodi.apps.coco.coco_merge import coco_merge
 
 
@@ -56,3 +57,37 @@ def test_coco_merge(tmp_path):
         range(len(data["annotations"]))
     )
     assert [i["category_id"] for i in data["annotations"]] == [1, 2, 1, 3, 3, 1]
+
+
+def test_coco_merge_with_json_indent(tmp_path):
+    images = [{"id": 0, "file_name": "0.jpg"}]
+    anns1 = [{"image_id": 0, "category_id": 0, "id": 0}]
+    anns2 = [{"image_id": 0, "category_id": 1, "id": 0}]
+    categories = [{"id": 0, "name": "excavator"}, {"id": 1, "name": "bus"}]
+
+    coco1 = dict(images=images, annotations=anns1, categories=categories)
+    coco2 = dict(images=images, annotations=anns2, categories=categories)
+
+    tmp_files = []
+    for i, coco_data in enumerate([coco1, coco2]):
+        tmp_files.append(tmp_path / f"{i}.json")
+        with open(tmp_files[-1], "w") as f:
+            json.dump(coco_data, f)
+
+    with patch("json.dump") as mock:
+        coco_merge(
+            input_extend=tmp_path / "0.json",
+            input_add=tmp_path / "1.json",
+            output_file=tmp_path / "result.json",
+            indent=None,
+        )
+        mock.assert_called_once_with(ANY, ANY, indent=None)
+
+    with patch("json.dump") as mock:
+        coco_merge(
+            input_extend=tmp_path / "0.json",
+            input_add=tmp_path / "1.json",
+            output_file=tmp_path / "result.json",
+            indent=2,
+        )
+        mock.assert_called_once_with(ANY, ANY, indent=2)


### PR DESCRIPTION
Thank you for providing this great library. I had the issue that merging two COCO files (each 2.8 MB in size) resulted in a 19 MB large COCO JSON file (too large in my opinion). The huge difference in size was caused by the JSON indentation which is set to 2 spaces:

https://github.com/Gradiant/pyodi/blob/d48b39c23b249f796291a5904a0e936b63367ab0/pyodi/apps/coco/coco_merge.py#L90-L91

**Previously:**

Merging two COCO files with fixed indentation of 2 spaces:

```python
from pyodi.apps import coco
coco.coco_merge('coco_annotations1.json', 'coco_annotations2.json', 'output.json')
```

resulted in:

```
-rw-rw-r--  1 phil phil 2,8M Dez 13 18:59 coco_annotations1.json
-rw-rw-r--  1 phil phil 2,8M Dez 13 18:59 coco_annotations2.json
-rw-rw-r--  1 phil phil  19M Dez 13 19:01 output.json
```

**With my changes:**

Merging the same two COCO files with indentation disabled by setting `json_indentation=None`:

```python
from pyodi.apps import coco
coco.coco_merge('coco_annotations1.json', 'coco_annotations2.json', 'output.json', json_indentation=None)
```

results in:

```
-rw-rw-r--  1 phil phil 2,8M Dez 13 18:59 coco_annotations1.json
-rw-rw-r--  1 phil phil 2,8M Dez 13 18:59 coco_annotations2.json
-rw-rw-r--  1 phil phil 5,6M Dez 13 19:01 output.json
```