### PR TITLE
Updated numpy version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ url = https://github.com/Gradiant/pyodi
 packages = find_namespace:
 python_requires = >=3.8
 install_requires =
-  numpy==1.22.1
+  numpy==1.23.5
   loguru==0.6.0
   matplotlib==3.5.2
   numba>=0.56.0


### PR DESCRIPTION
Input:
```
pip install pyodi
pyodi coco merge 1.json 2.json output.json
```
Output:
```
ValueError: numpy.ndarray size changed, may indicate binary incompatibility
```
When you run this code, the error will be fixed.
```
pip install numpy==1.23.5
```
