### PR TITLE
FIx automatic branch creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - name: Create Issue Branch
-          uses: robvanderleek/create-issue-branch@master
+          uses: robvanderleek/create-issue-branch@main
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #183 

## Summary

The branch has been changed from master to main to avoid the problem of not finding the master branch in the [actions](https://github.com/Gradiant/pyodi/actions), since the [create-issue-branch](https://github.com/robvanderleek/create-issue-branch) project uses the main branch.